### PR TITLE
Utils :: bugfix :: Incluindo validação para a data da exceção

### DIFF
--- a/src/Vitto/Utils.php
+++ b/src/Vitto/Utils.php
@@ -185,31 +185,39 @@ class Utils
             $arrayTimes = $opentime;
         }
 
-        foreach ($arrayTimes[$todayDay] as $key => $value){
-            if (!empty($value->extra) && strcmp($value->extra, $timeNow) > 0){
-                $isExtra = $value->extra;
-                $open = true;
-            }
-
-            if ($value->active == 1){
-                if ($value->close < $value->open ){
-                    $value->close = '23:59';
+        if(!empty($arrayTimes[$todayDay])) {
+            foreach ($arrayTimes[$todayDay] as $key => $value){
+                if (!empty($value->extra) && strcmp($value->extra, $timeNow) > 0){
+                    $isExtra = $value->extra;
+                    $open = true;
                 }
 
-                if ($timeNow >= $value->open and $timeNow <= $value->close) {
-                    $open = true;
+                if ($value->active == 1){
+                    if ($value->close < $value->open ){
+                        $value->close = '23:59';
+                    }
+
+                    if ($timeNow >= $value->open and $timeNow <= $value->close) {
+                        $open = true;
+                    }
                 }
             }
         }
+        
         /* Verifica Exceções */
         if (!empty($arrayExceptions)){
             foreach ($arrayExceptions as $key => $exception) {
+                $currentDate = date('Y-m-d');
+                if ( $currentDate != $exception->date ) {
+                    continue;
+                }
+
                 $exceptionTimes = json_decode($exception->times);
-                if ($exception->status == 'Fechado'){
+                if ($exception->status == 'Fechado') {
                     $open = false;
-                }else{
+                } else {
                     foreach ($exceptionTimes as $key => $period) {
-                        if ($period->close < $period->open ){
+                        if ($period->close < $period->open ) {
                             $period->close = '23:59';
                         }
                         if ($timeNow >= $period->open and $timeNow <= $period->close) {


### PR DESCRIPTION
Adicionei uma validação para ignorar a análise de uma exceção quando ela não pertencer ao dia corrente. Essa proteção foi incluída pelo fato da cache poder armazenar exceções do dia anterior.